### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 > **Curated AI prompts for developers, delivered through the Model Context Protocol**
 
+<a href="https://glama.ai/mcp/servers/@LeonNonnast/mcpdevprompts">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LeonNonnast/mcpdevprompts/badge" alt="Dev Prompt Server MCP server" />
+</a>
+
 A lightweight MCP server providing battle-tested prompts for AI-powered development workflows. Create specialized agents by combining modular skills, or use expert AI profiles for debugging, SQL optimization, and more.
 
 ## 🚀 Quick Start


### PR DESCRIPTION
This PR adds a badge for the [Dev MCP Prompt Server](https://glama.ai/mcp/servers/@LeonNonnast/mcpdevprompts) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@LeonNonnast/mcpdevprompts">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LeonNonnast/mcpdevprompts/badge" alt="Dev Prompt Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.